### PR TITLE
[cpu] move run_until_alarm out of crate cpu into crate cli.

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,6 +1,7 @@
 use std::ffi::OsString;
 use std::fs::File;
 use std::fs::OpenOptions;
+use std::time::Duration;
 
 use clap::{App, Arg};
 use tracing::{event, Level};
@@ -9,8 +10,95 @@ use tracing_subscriber::prelude::*;
 use base::prelude::*;
 use cpu::io::{Petr, TapeIterator};
 use cpu::{
-    run_until_alarm, BasicClock, Clock, ControlUnit, MemoryConfiguration, MemoryUnit, ResetMode,
+    Alarm, BasicClock, Clock, ControlUnit, MemoryConfiguration, MemoryUnit, MinimalSleeper,
+    ResetMode,
 };
+
+pub fn run_until_alarm(
+    control: &mut ControlUnit,
+    mem: &mut MemoryUnit,
+    clk: &mut BasicClock,
+    multiplier: Option<f64>,
+) -> Result<(), Alarm> {
+    let mut elapsed_ns: u64 = 0;
+    let mut sleeper = MinimalSleeper::new(Duration::from_millis(2));
+    let mut next_hw_poll = clk.now();
+
+    fn time_passes(
+        clk: &mut BasicClock,
+        sleeper: &mut MinimalSleeper,
+        t: &Duration,
+        multiplier: Option<f64>,
+    ) {
+        clk.consume(t);
+        if let Some(m) = multiplier {
+            sleeper.sleep(&t.mul_f64(m));
+        }
+    }
+
+    loop {
+        let now = clk.now();
+        if now >= next_hw_poll {
+            // check for I/O alarms, flag changes.
+            event!(Level::TRACE, "polling hardware for updates");
+            match control.poll_hardware(&now) {
+                Ok(Some(next)) => {
+                    next_hw_poll = next;
+                }
+                Ok(None) => {
+                    next_hw_poll = now + Duration::from_micros(5);
+                }
+                Err(e) => {
+                    event!(
+                        Level::INFO,
+                        "Alarm raised during hardware polling after {}ns",
+                        elapsed_ns
+                    );
+                    return Err(e);
+                }
+            }
+        }
+        let in_limbo = match control.fetch_instruction(mem) {
+            Err(e) => {
+                event!(
+                    Level::INFO,
+                    "Alarm raised during instruction fetch after {}ns",
+                    elapsed_ns
+                );
+                return Err(e);
+            }
+            Ok(some_sequence_is_runnable) => !some_sequence_is_runnable,
+        };
+        if in_limbo {
+            // No sequence is active, so there is no CPU instruction
+            // to execute.  Therefore we can only leave the limbo
+            // state in response to a hardware event.  We already know
+            // that we need to check for that at `next_hw_poll`.
+            let interval: Duration = next_hw_poll - now;
+            event!(
+                Level::TRACE,
+                "machine is in limbo, waiting {:?} for a flag to be raised",
+                &interval,
+            );
+            time_passes(clk, &mut sleeper, &interval, multiplier);
+            continue;
+        }
+        elapsed_ns += match control.execute_instruction(&clk.now(), mem) {
+            Err(e) => {
+                event!(
+                    Level::INFO,
+                    "Alarm raised during instruction execution after {}ns",
+                    elapsed_ns
+                );
+                return Err(e);
+            }
+            Ok(ns) => {
+                time_passes(clk, &mut sleeper, &Duration::from_nanos(ns), multiplier);
+                ns
+            }
+        };
+    }
+}
 
 fn run(
     control: &mut ControlUnit,

--- a/cpu/src/lib.rs
+++ b/cpu/src/lib.rs
@@ -2,10 +2,6 @@
 //! and the exchange unit.
 #![crate_name = "cpu"]
 
-use std::time::Duration;
-
-use tracing::{event, Level};
-
 mod alarm;
 mod clock;
 mod control;
@@ -17,89 +13,3 @@ pub use alarm::Alarm;
 pub use clock::{BasicClock, Clock, MinimalSleeper};
 pub use control::{ControlUnit, ResetMode};
 pub use memory::{MemoryConfiguration, MemoryUnit};
-
-fn time_passes(
-    clk: &mut BasicClock,
-    sleeper: &mut MinimalSleeper,
-    t: &Duration,
-    multiplier: Option<f64>,
-) {
-    clk.consume(t);
-    if let Some(m) = multiplier {
-        sleeper.sleep(&t.mul_f64(m));
-    }
-}
-
-pub fn run_until_alarm(
-    control: &mut ControlUnit,
-    mem: &mut MemoryUnit,
-    clk: &mut BasicClock,
-    multiplier: Option<f64>,
-) -> Result<(), Alarm> {
-    let mut elapsed_ns: u64 = 0;
-    let mut sleeper = MinimalSleeper::new(Duration::from_millis(2));
-    let mut next_hw_poll = clk.now();
-
-    loop {
-        let now = clk.now();
-        if now >= next_hw_poll {
-            // check for I/O alarms, flag changes.
-            event!(Level::TRACE, "polling hardware for updates");
-            match control.poll_hardware(&now) {
-                Ok(Some(next)) => {
-                    next_hw_poll = next;
-                }
-                Ok(None) => {
-                    next_hw_poll = now + Duration::from_micros(5);
-                }
-                Err(e) => {
-                    event!(
-                        Level::INFO,
-                        "Alarm raised during hardware polling after {}ns",
-                        elapsed_ns
-                    );
-                    return Err(e);
-                }
-            }
-        }
-        let in_limbo = match control.fetch_instruction(mem) {
-            Err(e) => {
-                event!(
-                    Level::INFO,
-                    "Alarm raised during instruction fetch after {}ns",
-                    elapsed_ns
-                );
-                return Err(e);
-            }
-            Ok(some_sequence_is_runnable) => !some_sequence_is_runnable,
-        };
-        if in_limbo {
-            // No sequence is active, so there is no CPU instruction
-            // to execute.  Therefore we can only leave the limbo
-            // state in response to a hardware event.  We already know
-            // that we need to check for that at `next_hw_poll`.
-            let interval: Duration = next_hw_poll - now;
-            event!(
-                Level::TRACE,
-                "machine is in limbo, waiting {:?} for a flag to be raised",
-                &interval,
-            );
-            time_passes(clk, &mut sleeper, &interval, multiplier);
-            continue;
-        }
-        elapsed_ns += match control.execute_instruction(&clk.now(), mem) {
-            Err(e) => {
-                event!(
-                    Level::INFO,
-                    "Alarm raised during instruction execution after {}ns",
-                    elapsed_ns
-                );
-                return Err(e);
-            }
-            Ok(ns) => {
-                time_passes(clk, &mut sleeper, &Duration::from_nanos(ns), multiplier);
-                ns
-            }
-        };
-    }
-}


### PR DESCRIPTION
The motivation is that this puts the "main loop" in the CLI itself,
meaning that the library doesn't implement the main control flow.
This should make it easier to integrate the simulator as a library.

This should fix #35 