### PR TITLE
Implement u18!() and u36!() convenience macros.

### DIFF
--- a/assembler/src/asmlib/tests.rs
+++ b/assembler/src/asmlib/tests.rs
@@ -1,6 +1,7 @@
 // Assembler tests.
 
 use base::prelude::*;
+use base::u36;
 use std::cell::RefCell;
 
 use nom::combinator::map;
@@ -105,7 +106,7 @@ fn test_normal_literal_instruction_fragment_oct_defaultmode() {
         parse_successfully_with("402", normal_literal_instruction_fragment, no_state_setup),
         InstructionFragment {
             elevation: Elevation::Normal,
-            value: Unsigned36Bit::from(0o402_u32),
+            value: u36!(0o402),
         }
     );
 }

--- a/base/src/lib.rs
+++ b/base/src/lib.rs
@@ -11,3 +11,40 @@ pub mod charset;
 pub mod instruction;
 pub mod prelude;
 pub mod subword;
+pub use crate::onescomplement::unsigned::*;
+
+#[macro_export]
+macro_rules! u36 {
+    ($n:expr) => {
+        $crate::prelude::Unsigned36Bit::new::<{ $n }>()
+    };
+}
+
+#[macro_export]
+macro_rules! u18 {
+    ($n:expr) => {
+        $crate::prelude::Unsigned18Bit::new::<{ $n }>()
+    };
+}
+
+#[test]
+fn test_u36() {
+    use prelude::Unsigned36Bit;
+    let m: Unsigned36Bit = u36!(40_u64);
+    let n: Unsigned36Bit = Unsigned36Bit::from(40_u32);
+    assert_eq!(m, n);
+
+    let p: Unsigned36Bit = u36!(1u64 << 34);
+    let q: Unsigned36Bit =
+        Unsigned36Bit::try_from(1u64 << 34).expect("test data should be in range");
+    assert_eq!(p, q);
+}
+
+#[test]
+fn test_u18() {
+    use prelude::Unsigned18Bit;
+    let p: Unsigned18Bit = u18!(1 << 17);
+    let q: Unsigned18Bit =
+        Unsigned18Bit::try_from(1u32 << 17).expect("test data should be in range");
+    assert_eq!(p, q);
+}

--- a/base/src/onescomplement/unsigned.rs
+++ b/base/src/onescomplement/unsigned.rs
@@ -132,6 +132,26 @@ macro_rules! unsigned_ones_complement_impl {
             pub const ONE: Self = Self { bits: 1 };
             pub const MIN: Self = Self::ZERO;
 
+            // This will always fail at compile time, so no need to
+            // hide it.  It's pub so that it can be used in u36!() and
+            // similar.
+            pub const fn new<const N: $InnerT>() -> $SelfT {
+                type Word = $SelfT;
+                struct Helper<const M: $InnerT>;
+                impl<const M: $InnerT> Helper<M> {
+                    const U: Word = {
+                        if M > Word::MAX.bits {
+                            panic!("input value is out of range")
+                        } else {
+                            Word {
+                                bits: Word::MAX.bits & M,
+                            }
+                        }
+                    };
+                }
+                Helper::<N>::U
+            }
+
             pub const fn is_zero(&self) -> bool {
                 self.bits == 0
             }

--- a/base/src/prelude.rs
+++ b/base/src/prelude.rs
@@ -9,3 +9,4 @@ pub use crate::subword::join_halves;
 pub use crate::subword::join_quarters;
 pub use crate::types::IndexBy;
 pub use crate::types::*;
+pub use crate::{u18, u36};

--- a/base/src/types.rs
+++ b/base/src/types.rs
@@ -75,6 +75,10 @@ impl Address {
     pub const ZERO: Address = Address(Unsigned18Bit::ZERO);
     pub const MAX: Address = Address(Unsigned18Bit::MAX);
 
+    pub const fn new(a: Unsigned18Bit) -> Address {
+        Address(a)
+    }
+
     /// Apply a bitmask to an address.  This could also be done via
     /// [`std::ops::BitAnd`], but trait implementations cannot be
     /// const.  Implementing this const methods allows us to form

--- a/cpu/src/memory.rs
+++ b/cpu/src/memory.rs
@@ -42,7 +42,7 @@ pub const U_MEMORY_SIZE: u32 = 1 + 0o0217777 - 0o0210000;
 pub const V_MEMORY_START: u32 = 0o0377600;
 pub const V_MEMORY_SIZE: u32 = 1 + 0o0377777 - 0o0377600;
 
-pub const STANDARD_PROGRAM_CLEAR_MEMORY: Address = Address::MAX.and(0o0377770_u32);
+pub const STANDARD_PROGRAM_CLEAR_MEMORY: Address = Address::new(u18!(0o0377770));
 
 #[derive(Debug)]
 pub enum MemoryOpFailure {


### PR DESCRIPTION
Idea from https://github.com/SkiFire13 (Giacomo Stevanato).

## Pull Request template

Please, fill in the following checklist when you submit a PR.  The
items you have done should be updated with a check mark (that is,
`[x]` instead of `[ ]`).

* [x] Review the [CONTRIBUTING.md](../CONTRIBUTING.md) file for
      detailed contributing guidelines before sending a PR.
* [x] Your contribution is made under the project's [copyright
      license](../LICENSE-MIT).
* [x] Make sure that your PR is not a duplicate.
* [x] You have done your changes in a separate branch.
* [x] You have a descriptive commit message with a short title (first line).
* [x] You have only one commit.  If not, either squash them into one
      commit or contribute your change as a sequence of smaller Pull
      Requests.
* [x] Your changes include unit tests (if they are code changes).
* [x] `cargo test` passes.
* [x] `cargo clippy` does not generate any warnings.
* [x] Your code is formatted with `cargo fmt`.
* If your change is a bugfix and it fully fixes an issue:
   * [ ] Put `closes #XXXX` in your commit message to auto-close the
         issue that your PR fixes.
* [ ] If your change relates to the behaviour of the simulator, please
      include comments explaining which part of the [reference
      documentation](https://tx-2.github.io/documentation.html)
      describes the thing you're changing.

If any of the checklist items don't apply, please leave them
un-checked.

**PLEASE KEEP THE ABOVE IN YOUR PULL REQUEST.**
