### PR TITLE
Exchange unit: is directional, fix sign extension.

### DIFF
--- a/base/src/onescomplement/unsigned.rs
+++ b/base/src/onescomplement/unsigned.rs
@@ -218,6 +218,15 @@ macro_rules! unsigned_ones_complement_impl {
                     bits: self.bits & mask,
                 }
             }
+
+            // We cannot call std::ops::BitOr in a const because trait
+            // methods cannot be const.  So we have this work-alike in
+            // impl, since it can be called in a const context.
+            pub const fn bitor(self, mask: $InnerT) -> Self {
+                Self {
+                    bits: self.bits | mask,
+                }
+            }
         }
 
         impl WordCommon for $SelfT {

--- a/base/src/prelude.rs
+++ b/base/src/prelude.rs
@@ -7,7 +7,7 @@ pub use crate::onescomplement::signed::*;
 pub use crate::onescomplement::unsigned::*;
 pub use crate::readerleader::reader_leader;
 pub use crate::splay::{cycle_and_splay, unsplay};
-pub use crate::subword::{join_halves, join_quarters, split_halves};
+pub use crate::subword::{join_halves, join_quarters, left_half, right_half, split_halves};
 pub use crate::types::IndexBy;
 pub use crate::types::*;
 pub use crate::{u18, u36, u5, u6, u9};

--- a/cpu/src/control/op_configuration.rs
+++ b/cpu/src/control/op_configuration.rs
@@ -27,7 +27,7 @@ impl ControlUnit {
     pub fn op_spg(&mut self, mem: &mut MemoryUnit) -> Result<(), Alarm> {
         let c = usize::from(self.regs.n.configuration());
         let target = self.operand_address_with_optional_defer_and_index(mem)?;
-        let (word, _meta) = self.fetch_operand_from_address(mem, &target)?;
+        let (word, _meta) = self.fetch_operand_from_address_without_exchange(mem, &target)?;
         for (quarter_number, cfg_value) in subword::quarters(word).iter().rev().enumerate() {
             let pos = c + quarter_number;
             let newvalue = (*cfg_value).into();


### PR DESCRIPTION
Make the exchange unit behave differently in the E->M and M->E
directions.  This follows the explanation in chapter 13 of the Users
Handbook.

Also fix sign extension.  It doesn't happen in the E->M direction and
the sign bit of a quarter is 0o400, not 0o300.

Add test cases for the RSX instruction which correspond to the
examples in the instruction definition in the Users Handbook.

## Pull Request template

Please, fill in the following checklist when you submit a PR.  The
items you have done should be updated with a check mark (that is,
`[x]` instead of `[ ]`).

* [x] Review the [CONTRIBUTING.md](../CONTRIBUTING.md) file for
      detailed contributing guidelines before sending a PR.
* [x] Your contribution is made under the project's [copyright
      license](../LICENSE-MIT).
* [x] Make sure that your PR is not a duplicate.
* [x] You have done your changes in a separate branch.
* [x] You have a descriptive commit message with a short title (first line).
* [x] You have only one commit.  If not, either squash them into one
      commit or contribute your change as a sequence of smaller Pull
      Requests.
* [x] Your changes include unit tests (if they are code changes).
* [x] `cargo test` passes.
* [x] `cargo clippy` does not generate any warnings.
* [x] Your code is formatted with `cargo fmt`.
* If your change is a bugfix and it fully fixes an issue:
   * [x] Put `closes #XXXX` in your commit message to auto-close the
         issue that your PR fixes.
* [x] If your change relates to the behaviour of the simulator, please
      include comments explaining which part of the [reference
      documentation](https://tx-2.github.io/documentation.html)
      describes the thing you're changing.

If any of the checklist items don't apply, please leave them
un-checked.

**PLEASE KEEP THE ABOVE IN YOUR PULL REQUEST.**

closes #55 
closes #54
