### PR TITLE
Refactoring of how TSD works to simplify memory access.

### DIFF
--- a/base/src/onescomplement/unsigned.rs
+++ b/base/src/onescomplement/unsigned.rs
@@ -9,7 +9,7 @@ use std::cmp::Ordering;
 use std::fmt::{self, Debug, Display, Formatter, Octal};
 use std::hash::{Hash, Hasher};
 
-use super::super::subword::split_halves;
+use super::super::subword::{right_half, split_halfword, split_halves};
 use super::error::ConversionFailed;
 use super::signed::*;
 use super::{Sign, WordCommon};
@@ -770,6 +770,31 @@ impl From<Unsigned18Bit> for Unsigned36Bit {
     fn from(n: Unsigned18Bit) -> Self {
         Self {
             bits: n.bits.into(),
+        }
+    }
+}
+
+impl std::ops::BitAnd<Unsigned18Bit> for Unsigned36Bit {
+    type Output = Unsigned18Bit;
+    fn bitand(self, rhs: Unsigned18Bit) -> Unsigned18Bit {
+        right_half(self).bitand(rhs)
+    }
+}
+
+impl std::ops::BitAnd<Unsigned9Bit> for Unsigned36Bit {
+    type Output = Unsigned9Bit;
+    fn bitand(self, rhs: Unsigned9Bit) -> Unsigned9Bit {
+        let (_q2, q1) = split_halfword(right_half(self));
+        q1.bitand(rhs)
+    }
+}
+
+impl std::ops::BitAnd<Unsigned6Bit> for Unsigned36Bit {
+    type Output = Unsigned6Bit;
+    fn bitand(self, rhs: Unsigned6Bit) -> Unsigned6Bit {
+        Unsigned6Bit {
+            bits: u8::try_from(self.bits & 0o77).expect("a six-bit quantity should be in-range")
+                & rhs.bits,
         }
     }
 }

--- a/cpu/src/control/op_index.rs
+++ b/cpu/src/control/op_index.rs
@@ -39,7 +39,7 @@ impl ControlUnit {
 
         // DPX is trying to perform a write.  But to do this in some
         // subword configurations, we need to read the existing value.
-        match self.fetch_operand_from_address_without_exchange(mem, &target, &UpdateE::Yes) {
+        match self.fetch_operand_from_address_without_exchange(mem, &target, &UpdateE::No) {
             Ok((dest, _meta)) => self
                 .memory_store_with_exchange(
                     mem,

--- a/cpu/src/control/op_io.rs
+++ b/cpu/src/control/op_io.rs
@@ -1,18 +1,42 @@
+use std::ops::BitAnd;
+
 use base::prelude::*;
 use std::time::Duration;
 
 use tracing::{event, Level};
 
-use crate::alarm::{Alarm, AlarmUnit};
+use super::super::*;
+use crate::alarm::{Alarm, AlarmUnit, BadMemOp};
 use crate::control::{
     ControlRegisters, ControlUnit, DeviceManager, OpcodeResult, ProgramCounterChange, TrapCircuit,
 };
-use crate::io::{FlagChange, TransferOutcome, Unit};
-use crate::memory::{MemoryUnit, MetaBitChange};
+use crate::exchanger::exchanged_value_for_load;
+use crate::io::Unit;
+use crate::memory::{MemoryMapped, MemoryOpFailure, MemoryUnit, MetaBitChange};
+
+#[derive(Debug, PartialEq, Eq)]
+enum TransferOutcome {
+    /// When the outcome is successful, let the caller know if the
+    /// memory location's meta bit was set.  This allows the trap
+    /// circuit to be triggered if necessary.
+    Success(bool),
+
+    /// When the outcome of the TSD is dismiss and wait, we don't
+    /// trigger the trap circuit (not because we think the TX-2 behaved
+    /// this way, but because it keeps the code simpler and we don't
+    /// know if the oposite behaviour is needed).
+    DismissAndWait,
+}
+
+type OpConversion = fn(Address) -> BadMemOp;
+
+fn bad_write(addr: Address) -> BadMemOp {
+    BadMemOp::Write(addr.into())
+}
 
 impl ControlUnit {
     /// Implements the IOS opcode
-    pub fn op_ios(&mut self, system_time: &Duration) -> OpcodeResult {
+    pub fn op_ios(&mut self, devices: &mut DeviceManager, system_time: &Duration) -> OpcodeResult {
         let j = self.regs.n.index_address();
         let cf = self.regs.n.configuration();
 
@@ -22,9 +46,7 @@ impl ControlUnit {
             // change to be copied into the E register.  (as stated in
             // section 4-3.6 of the User Handbook).
             let flag_raised: bool = self.regs.flags.current_flag_state(&j);
-            self.regs.e = self
-                .devices
-                .report(system_time, j, flag_raised, &self.alarm_unit)?;
+            self.regs.e = devices.report(system_time, j, flag_raised, &self.alarm_unit)?;
         }
         let mut dismiss_reason: Option<&str> = if cf & 0o20 != 0 {
             Some("dismiss bit set in config")
@@ -34,11 +56,11 @@ impl ControlUnit {
 
         let operand = self.regs.n.operand_address_and_defer_bit();
         let result = match u32::from(operand) {
-            0o20_000 => self.disconnect_unit(j),
+            0o20_000 => devices.disconnect(&j, &self.alarm_unit),
             0o30_000..=0o37_777 => {
                 let mode: Unsigned12Bit = Unsigned12Bit::try_from(operand & 0o07_777).unwrap();
                 ControlUnit::connect_unit(
-                    &mut self.devices,
+                    devices,
                     &mut self.regs,
                     &mut self.trap,
                     system_time,
@@ -113,67 +135,180 @@ impl ControlUnit {
         Ok(())
     }
 
-    fn disconnect_unit(&mut self, unit: Unsigned6Bit) -> Result<(), Alarm> {
-        match u8::from(unit) {
-            0o42 => Ok(()),
-            _ => self.devices.disconnect(&unit, &self.alarm_unit),
-        }
-    }
-
     pub fn op_tsd(
         &mut self,
+        devices: &mut DeviceManager,
         execution_address: Address,
         system_time: &Duration,
         mem: &mut MemoryUnit,
     ) -> OpcodeResult {
-        if let Some(unit) = self.regs.k {
-            let cf = self.regs.n.configuration();
+        fn make_tsd_qsal(inst: Instruction, op: BadMemOp) -> Alarm {
+            Alarm::QSAL(inst, op, "TSD address is not mapped".to_string())
+        }
+
+        let result: Result<TransferOutcome, Alarm> = if let Some(unit) = self.regs.k {
             let target: Address = self.operand_address_with_optional_defer_and_index(mem)?;
+            let not_mapped = |op_conv: OpConversion| -> Alarm {
+                let op: BadMemOp = op_conv(target);
+                make_tsd_qsal(self.regs.n, op)
+            };
+
             let meta_op: MetaBitChange = if self.trap.set_metabits_of_operands() {
                 MetaBitChange::Set
             } else {
                 MetaBitChange::None
             };
-            match self.devices.transfer(
-                system_time,
-                &unit,
-                &cf,
-                &target,
-                mem,
-                &self.regs.n,
-                &meta_op,
-                &self.alarm_unit,
-            ) {
-                Ok(TransferOutcome::Success(meta_bit_set)) => {
-                    if meta_bit_set && self.trap.trap_on_operand() {
-                        self.raise_trap();
+            // There are no sequence numbers below 0o40, besides 0.
+            if matches!(u8::from(unit), 0 | 0o75 | 0o76) {
+                // Non-INOUT sequences just cycle the target location;
+                // see section 4-1 (page 4-3) of the Users Handbook;
+                // also pages 4-2 and 4-9).
+                match mem.cycle_word(&target) {
+                    Ok(extra_bits) => Ok(TransferOutcome::Success(extra_bits.meta)),
+                    Err(MemoryOpFailure::ReadOnly(_address, extra_bits)) => {
+                        // The read-only case is not an error, it's
+                        // normal.  The TSD instruction simply has no
+                        // effect when the target address is
+                        // read-only.
+                        // TODO: should there be an effect on the E register?
+                        Ok(TransferOutcome::Success(extra_bits.meta))
                     }
-                    Ok(None)
-                }
-                Ok(TransferOutcome::DismissAndWait) => {
-                    if unit == Unsigned6Bit::ZERO {
-                        event!(Level::WARN, "Ignoring TSD dismiss and wait for sequence 0",);
-                        Ok(None)
-                    } else {
-                        // In the dismiss and wait case, the
-                        // sequence is dismissed even if the hold
-                        // bit is set (Users Handbook, section
-                        // 4-3.2).  The hold bit only governs what
-                        // happens following the completion of an
-                        // instruction.
-                        self.dismiss("TSD while data was not ready caused dismiss-and-wait");
-                        Ok(Some(ProgramCounterChange::DismissAndWait(
-                            execution_address,
-                        )))
+                    Err(MemoryOpFailure::NotMapped(_)) => {
+                        self.alarm_unit.fire_if_not_masked(not_mapped(bad_write))?;
+                        // QSAL is masked, carry on.
+                        Ok(TransferOutcome::Success(false)) // act as if metabit unset
                     }
                 }
-                Err(e) => Err(e),
+            } else {
+                match devices.get_mut(&unit) {
+                    None => {
+                        event!(Level::WARN, "TSD on unknown unit {:o}", unit);
+                        Ok(TransferOutcome::DismissAndWait)
+                    }
+                    Some(device) => {
+                        let is_input_unit = device.is_input_unit;
+                        if !device.connected {
+                            // If the unit is not connected, perform
+                            // dismiss and wait.  This requirement is
+                            // described in section 4-3.7 of the Users
+                            // Handbook.
+                            Ok(TransferOutcome::DismissAndWait)
+                        } else if device.in_maintenance {
+                            event!(
+                                Level::WARN,
+                                "TSD on unit {:o}, but it is in maintenance",
+                                unit
+                            );
+                            Ok(TransferOutcome::DismissAndWait)
+                        } else {
+                            // We're actually going to do the (input or output) transfer.
+                            // First load into the M register the existing contents of
+                            // memory.
+                            let transfer_mode = device.transfer_mode();
+                            let (m_register, extra_bits) = self
+                                .fetch_operand_from_address_without_exchange(
+                                    mem,
+                                    &target,
+                                    &UpdateE::No,
+                                )?;
+                            if is_input_unit {
+                                // In read operations, data is transferred
+                                // from the I/O device's buffer over the
+                                // IOBM bus, into the E register.  See
+                                // figure 15-18 in Volume 2 of the TX-2
+                                // Techical Manual.
+                                match device.read(system_time) {
+                                    Ok(masked_word) => {
+                                        const UPDATE_E_YES: UpdateE = UpdateE::Yes;
+                                        let newval: Unsigned36Bit =
+                                            masked_word.apply(Unsigned36Bit::ZERO);
+                                        match transfer_mode {
+                                            TransferMode::Assembly => {
+                                                let bits: Unsigned6Bit =
+                                                    newval.bitand(Unsigned6Bit::MAX);
+                                                self.memory_store_without_exchange(
+                                                    mem,
+                                                    &target,
+                                                    &cycle_and_splay(m_register, bits),
+                                                    &UPDATE_E_YES,
+                                                    &meta_op,
+                                                )?;
+                                            }
+                                            TransferMode::Exchange => {
+                                                self.memory_store_with_exchange(
+                                                    mem,
+                                                    &target,
+                                                    &newval,
+                                                    &m_register,
+                                                    &UPDATE_E_YES,
+                                                    &meta_op,
+                                                )?;
+                                            }
+                                        }
+                                        Ok(TransferOutcome::Success(extra_bits.meta))
+                                    }
+                                    Err(e) => match e {
+                                        TransferFailed::BufferNotFree => {
+                                            Ok(TransferOutcome::DismissAndWait)
+                                        }
+                                    },
+                                }
+                            } else {
+                                // In write operations, data is
+                                // transferred from the E register to the
+                                // I/O device over the E bus.
+                                self.regs.e = exchanged_value_for_load(
+                                    &self.get_config(),
+                                    &m_register,
+                                    &self.regs.e,
+                                );
+                                match transfer_mode {
+                                    TransferMode::Exchange => {
+                                        match device.write(system_time, self.regs.e) {
+                                            Err(TransferFailed::BufferNotFree) => {
+                                                Ok(TransferOutcome::DismissAndWait)
+                                            }
+                                            Ok(()) => Ok(TransferOutcome::Success(extra_bits.meta)),
+                                        }
+                                    }
+                                    TransferMode::Assembly => {
+                                        Err(self.alarm_unit.always_fire(Alarm::ROUNDTUITAL(
+                                            "TSD output in assembly mode is not yet implemented."
+                                                .to_string(),
+                                        )))
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
             }
         } else {
             Err(self.alarm_unit.always_fire(Alarm::BUGAL {
 		instr: Some(self.regs.n),
 		message: "Executed TSD instruction while the K register is None (i.e. there is no current sequence)".to_string(),
 	    }))
+        };
+        match result {
+            Ok(TransferOutcome::Success(meta_bit_set)) => {
+                if meta_bit_set && self.trap.trap_on_operand() {
+                    self.raise_trap();
+                }
+                Ok(None)
+            }
+            Ok(TransferOutcome::DismissAndWait) => {
+                // In the dismiss and wait case, the
+                // sequence is dismissed even if the hold
+                // bit is set (Users Handbook, section
+                // 4-3.2).  The hold bit only governs what
+                // happens following the completion of an
+                // instruction.
+                self.dismiss("TSD while data was not ready caused dismiss-and-wait");
+                Ok(Some(ProgramCounterChange::DismissAndWait(
+                    execution_address,
+                )))
+            }
+            Err(e) => Err(e),
         }
     }
 }

--- a/cpu/src/lib.rs
+++ b/cpu/src/lib.rs
@@ -10,12 +10,14 @@ mod control;
 mod exchanger;
 pub mod io;
 mod memory;
+mod types;
 
 pub use alarm::Alarm;
 pub use clock::{BasicClock, Clock, MinimalSleeper};
 pub use control::{ControlUnit, PanicOnUnmaskedAlarm, ResetMode, RunMode};
-pub use io::{set_up_peripherals, TapeIterator};
+pub use io::{set_up_peripherals, DeviceManager, TapeIterator};
 pub use memory::{MemoryConfiguration, MemoryUnit};
+pub use types::*;
 
 pub fn time_passes(
     clk: &mut BasicClock,

--- a/cpu/src/types.rs
+++ b/cpu/src/types.rs
@@ -1,0 +1,52 @@
+use std::fmt::{self, Debug, Display, Formatter};
+
+use base::prelude::*;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FlagChange {
+    Raise,
+}
+
+/// A value of which bits 0..width are significant (0 being the least significant bit).
+// Hence a six-bit value would be `MaskedWord { width: 6, value: u13!(0o77) }`
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MaskedWord {
+    pub bits: Unsigned36Bit,
+    pub mask: Unsigned36Bit,
+}
+
+impl MaskedWord {
+    pub fn apply(&self, dest: Unsigned36Bit) -> Unsigned36Bit {
+        (dest & !self.mask) | (self.bits & self.mask)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransferMode {
+    /// TSD instructions use the exchange unit (but not sign extension).
+    Exchange,
+    /// TSD instructions use assembly mode.
+    Assembly,
+}
+
+#[derive(Debug)]
+pub enum TransferFailed {
+    BufferNotFree,
+}
+
+impl Display for TransferFailed {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+        f.write_str(match self {
+            TransferFailed::BufferNotFree => "Unit buffer not available for use by the CPU",
+        })
+    }
+}
+
+impl std::error::Error for TransferFailed {}
+
+/// Determines whether a memory operation updates the E register.
+#[derive(Debug)]
+pub enum UpdateE {
+    No,
+    Yes,
+}


### PR DESCRIPTION
In short, devices are no longer responsible for performing memory
updates temselves, instead they present a simulated I/O buffer.

This change also makes it possible for PETR reads in "normal" mode to
use the exchange element.

## Pull Request template

Please, fill in the following checklist when you submit a PR.  The
items you have done should be updated with a check mark (that is,
`[x]` instead of `[ ]`).

* [x] Review the [CONTRIBUTING.md](../CONTRIBUTING.md) file for
      detailed contributing guidelines before sending a PR.
* [x] Your contribution is made under the project's [copyright
      license](../LICENSE-MIT).
* [x] Make sure that your PR is not a duplicate.
* [x] You have done your changes in a separate branch.
* [x] You have a descriptive commit message with a short title (first line).
* [x] You have only one commit.  If not, either squash them into one
      commit or contribute your change as a sequence of smaller Pull
      Requests.
* [ ] Your changes include unit tests (if they are code changes).
* [x] `cargo test` passes.
* [x] `cargo clippy` does not generate any warnings.
* [x] Your code is formatted with `cargo fmt`.
* If your change is a bugfix and it fully fixes an issue:
   * [ ] Put `closes #XXXX` in your commit message to auto-close the
         issue that your PR fixes.
* [x] If your change relates to the behaviour of the simulator, please
      include comments explaining which part of the [reference
      documentation](https://tx-2.github.io/documentation.html)
      describes the thing you're changing.

If any of the checklist items don't apply, please leave them
un-checked.

**PLEASE KEEP THE ABOVE IN YOUR PULL REQUEST.**

Tested manually by loading a tape.
