### PR TITLE
[assembler] Assemble instructions containing opcodes.

### DIFF
--- a/assembler/README.md
+++ b/assembler/README.md
@@ -8,32 +8,50 @@ assembler, "M4".  Since this is a cross-assembler, some features (such
 as invoking the assembled program directly) likely will not be
 implemented.
 
-The assembler is very basic right now. For example, neither opcodes
-nor symbols are supported yet.  However, it can be used to generate
-basic test programs.
+The assembler is very basic right now.  However, it can be used to
+generate simple test programs.
 
 ## Example
 
 Here's an example input:
 
 <pre>
-100| 0
-     0
-☛☛PUNCH 101
+100|               0
+200| h ²¹IOS₅₂ 30106
+     h   STE     100
+         0
+☛☛PUNCH 200
 </pre>
 
-This program consists of two words, both zero (they're not valid
-instructions).  It will be loaded at memory address 100 octal.  The
-program entry point is 101 octal.
+This program consists of four words:
+
+* 100: a data storage location
+* 200: connect the paper tape reader (leaving its status word in register E)
+* 201: store the status word at location 100.
+* 202: an invalid instruction which (by default) causes the simulator to stop.
 
 If you put the above assembly language program in the file
-`example.tx2as` you can assemble it like this:
+`ios.tx2as` you can assemble it like this:
 
 ```
-cargo run --bin  tx2m4as -- --output 100.tape example.tx2as
+cargo run --bin  tx2m4as -- --output ios.tape ios.tx2as
 ```
 
-The output goes to the file `100.tape`.
+The output goes to the file `ios.tape`.
+
+## Limitations
+
+The assembler isn't finished yet, so there are a number of quite
+severe limitations:
+
+* No support yet for comments.
+* No symbol table, so tags, origins, addresses etc. cannot be symbols.
+* No expression evaluation, so we cannot use arithmetic expressions
+  (though please note that the TX-2 assembler, M4, had ideas of
+  operator precedence which don't reflect normal usage).
+* No support for deferred operands or RC words.
+* No support for macros.  Confusingly, the TX-2 assembler supported
+  macros and was called M4, but is unrelated to the Unix program `m4`.
 
 ## Documentation
 

--- a/assembler/src/asmlib/driver.rs
+++ b/assembler/src/asmlib/driver.rs
@@ -5,6 +5,8 @@ use std::io::{BufReader, BufWriter, Read, Write};
 
 use tracing::{event, span, Level};
 
+#[cfg(test)]
+use crate::parser::HoldBit;
 use crate::parser::{
     source_file, ErrorLocation, ManuscriptBlock, ManuscriptItem, ManuscriptMetaCommand, Origin,
     ProgramInstruction,
@@ -341,6 +343,7 @@ fn test_assemble_pass1() {
     let expected_block = Block {
         items: vec![ProgramInstruction {
             tag: None,
+            holdbit: HoldBit::Unspecified,
             parts: vec![InstructionFragment {
                 elevation: Elevation::Normal,
                 value: u36!(0o14),


### PR DESCRIPTION
Also assemble hold bits and update the example in README.md.

This change also implements the "implied" hold for opcodes JPX, JNX,
LDE, ITE as stated in the Users Handbook, section 4-3.2 on page 4-5.

## Pull Request template

Please, fill in the following checklist when you submit a PR.  The
items you have done should be updated with a check mark (that is,
`[x]` instead of `[ ]`).

* [x] Review the [CONTRIBUTING.md](../CONTRIBUTING.md) file for
      detailed contributing guidelines before sending a PR.
* [x] Your contribution is made under the project's [copyright
      license](../LICENSE-MIT).
* [x] Make sure that your PR is not a duplicate.
* [x] You have done your changes in a separate branch.
* [x] You have a descriptive commit message with a short title (first line).
* [x] You have only one commit.  If not, either squash them into one
      commit or contribute your change as a sequence of smaller Pull
      Requests.
* [x] Your changes include unit tests (if they are code changes).
* [x] `cargo test` passes.
* [x] `cargo clippy` does not generate any warnings.
* [x] Your code is formatted with `cargo fmt`.
* If your change is a bugfix and it fully fixes an issue:
   * [ ] Put `closes #XXXX` in your commit message to auto-close the
         issue that your PR fixes.
* [x] If your change relates to the behaviour of the simulator, please
      include comments explaining which part of the [reference
      documentation](https://tx-2.github.io/documentation.html)
      describes the thing you're changing.

If any of the checklist items don't apply, please leave them
un-checked.

**PLEASE KEEP THE ABOVE IN YOUR PULL REQUEST.**
