### PR TITLE
Factor KeyedReversePriorityQueue out into the base crate.

### DIFF
--- a/base/Cargo.toml
+++ b/base/Cargo.toml
@@ -11,3 +11,4 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+keyed_priority_queue = "0.4.1"	# MIT license

--- a/base/src/collections.rs
+++ b/base/src/collections.rs
@@ -1,0 +1,1 @@
+pub mod pq;

--- a/base/src/collections/pq.rs
+++ b/base/src/collections/pq.rs
@@ -1,0 +1,163 @@
+use std::cmp::Ordering;
+use std::fmt::{self, Debug, Formatter};
+use std::hash::Hash;
+
+use keyed_priority_queue::KeyedPriorityQueue;
+
+#[derive(Debug)]
+struct ReverseOrdered<T> {
+    inner: T,
+}
+
+impl<T> From<T> for ReverseOrdered<T> {
+    fn from(inner: T) -> ReverseOrdered<T> {
+        ReverseOrdered { inner }
+    }
+}
+
+impl<T: Ord> PartialOrd for ReverseOrdered<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<T: Eq> Eq for ReverseOrdered<T> {}
+
+impl<T: Eq> PartialEq for ReverseOrdered<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.inner == other.inner
+    }
+}
+
+impl<T: Ord> Ord for ReverseOrdered<T> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match self.inner.cmp(&other.inner) {
+            Ordering::Less => Ordering::Greater,
+            Ordering::Equal => Ordering::Equal,
+            Ordering::Greater => Ordering::Less,
+        }
+    }
+}
+
+#[test]
+fn test_reverse_order() {
+    assert_eq!(ReverseOrdered::from(1), ReverseOrdered::from(1));
+    assert_ne!(ReverseOrdered::from(1), ReverseOrdered::from(0));
+    assert!(ReverseOrdered::from(1) < ReverseOrdered::from(0));
+    assert_ne!(ReverseOrdered::from(1), ReverseOrdered::from(0));
+    assert!(!(ReverseOrdered::from(1) > ReverseOrdered::from(0)));
+}
+
+pub struct KeyedReversePriorityQueueUnknownKeyError {}
+
+pub struct KeyedReversePriorityQueue<K: Hash + Eq + Ord, P: Ord> {
+    items: KeyedPriorityQueue<K, ReverseOrdered<P>>,
+}
+
+impl<K, P> KeyedReversePriorityQueue<K, P>
+where
+    K: Hash + Eq + Ord,
+    P: Ord,
+{
+    pub fn new() -> KeyedReversePriorityQueue<K, P> {
+        KeyedReversePriorityQueue {
+            items: KeyedPriorityQueue::<K, ReverseOrdered<P>>::new(),
+        }
+    }
+
+    pub fn peek(&self) -> Option<(&K, &P)> {
+        self.items.peek().map(|(k, p)| (k, &p.inner))
+    }
+
+    pub fn pop(&mut self) -> Option<(K, P)> {
+        self.items.pop().map(|(k, p)| (k, p.inner))
+    }
+
+    pub fn push(&mut self, key: K, priority: P) -> Option<P> {
+        self.items
+            .push(key, ReverseOrdered::from(priority))
+            .map(|rd| rd.inner)
+    }
+
+    pub fn set_priority(
+        &mut self,
+        key: &K,
+        priority: P,
+    ) -> Result<P, KeyedReversePriorityQueueUnknownKeyError> {
+        match self.items.set_priority(key, ReverseOrdered::from(priority)) {
+            Ok(priority) => Ok(priority.inner),
+            Err(_) => Err(KeyedReversePriorityQueueUnknownKeyError {}),
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.items.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.items.is_empty()
+    }
+}
+
+impl<K, P> Debug for KeyedReversePriorityQueue<K, P>
+where
+    K: Hash + Eq + Ord + Debug,
+    P: Ord + Debug,
+{
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("KeyedReversePriorityQueue")
+            .field("items", &self.items)
+            .finish()
+    }
+}
+
+#[test]
+fn test_empty() {
+    let mut q: KeyedReversePriorityQueue<usize, usize> = KeyedReversePriorityQueue::new();
+    assert!(q.is_empty());
+    assert_eq!(0, q.len());
+    assert_eq!(q.peek(), None);
+    assert_eq!(q.pop(), None);
+}
+
+#[test]
+fn test_nonempty() {
+    let mut q: KeyedReversePriorityQueue<String, String> = KeyedReversePriorityQueue::new();
+    assert!(q.is_empty());
+    assert_eq!(
+        q.push(
+            "Muztagh Tower".to_string(),
+            "Joe Brown, Ian McNaught-Davis".to_string()
+        ),
+        None
+    );
+    assert!(!q.is_empty());
+}
+
+#[test]
+fn test_repeat_push() {
+    let mut q: KeyedReversePriorityQueue<usize, char> = KeyedReversePriorityQueue::new();
+    assert_eq!(q.push(0, '2'), None);
+    assert_eq!(q.push(0, '4'), Some('2'));
+    assert_eq!(q.push(0, '3'), Some('4'));
+    assert_eq!(q.pop(), Some((0, '3')));
+    assert!(q.is_empty());
+}
+
+#[test]
+fn test_ordering() {
+    let mut q: KeyedReversePriorityQueue<usize, char> = KeyedReversePriorityQueue::new();
+    assert_eq!(q.push(0, '2'), None);
+    assert_eq!(q.push(1, '8'), None);
+    assert_eq!(q.pop(), Some((0, '2')));
+    assert_eq!(q.pop(), Some((1, '8')));
+    assert!(q.is_empty());
+
+    // Now push them in the opposite order to prove that pop order
+    // depends on priority, not insertion order.
+    assert_eq!(q.push(1, '8'), None);
+    assert_eq!(q.push(0, '2'), None);
+    assert_eq!(q.pop(), Some((0, '2')));
+    assert_eq!(q.pop(), Some((1, '8')));
+    assert!(q.is_empty());
+}

--- a/base/src/lib.rs
+++ b/base/src/lib.rs
@@ -8,6 +8,7 @@ mod onescomplement;
 mod types;
 
 pub mod charset;
+pub mod collections;
 pub mod instruction;
 pub mod prelude;
 pub mod readerleader;

--- a/cpu/Cargo.toml
+++ b/cpu/Cargo.toml
@@ -12,7 +12,6 @@ publish = false
 [dependencies]
 base = { path = "../base" }
 tracing = "0.1" # MIT license
-keyed_priority_queue = "0.4.1"	# MIT license
 
 [lib]
 name = "cpu"

--- a/cpu/src/io/pollq.rs
+++ b/cpu/src/io/pollq.rs
@@ -1,57 +1,12 @@
-use std::cmp::Ordering;
+use std::fmt::Debug;
 use std::time::Duration;
 
-use keyed_priority_queue::KeyedPriorityQueue;
-
+use base::collections::pq::KeyedReversePriorityQueue;
 use base::prelude::*;
 
 #[derive(Debug)]
-struct ReverseOrdered<T> {
-    inner: T,
-}
-
-impl<T> From<T> for ReverseOrdered<T> {
-    fn from(inner: T) -> ReverseOrdered<T> {
-        ReverseOrdered { inner }
-    }
-}
-
-impl<T: Ord> PartialOrd for ReverseOrdered<T> {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl<T: Eq> Eq for ReverseOrdered<T> {}
-
-impl<T: Eq> PartialEq for ReverseOrdered<T> {
-    fn eq(&self, other: &Self) -> bool {
-        self.inner == other.inner
-    }
-}
-
-impl<T: Ord> Ord for ReverseOrdered<T> {
-    fn cmp(&self, other: &Self) -> Ordering {
-        match self.inner.cmp(&other.inner) {
-            Ordering::Less => Ordering::Greater,
-            Ordering::Equal => Ordering::Equal,
-            Ordering::Greater => Ordering::Less,
-        }
-    }
-}
-
-#[test]
-fn test_reverse_order() {
-    assert_eq!(ReverseOrdered::from(1), ReverseOrdered::from(1));
-    assert_ne!(ReverseOrdered::from(1), ReverseOrdered::from(0));
-    assert!(ReverseOrdered::from(1) < ReverseOrdered::from(0));
-    assert_ne!(ReverseOrdered::from(1), ReverseOrdered::from(0));
-    assert!(!(ReverseOrdered::from(1) > ReverseOrdered::from(0)));
-}
-
-#[derive(Debug)]
 pub struct PollQueue {
-    items: KeyedPriorityQueue<SequenceNumber, ReverseOrdered<Duration>>,
+    items: KeyedReversePriorityQueue<SequenceNumber, Duration>,
 }
 
 #[derive(Debug)]
@@ -62,22 +17,20 @@ pub enum PollQueueUpdateFailure {
 impl PollQueue {
     pub fn new() -> PollQueue {
         PollQueue {
-            items: KeyedPriorityQueue::new(),
+            items: KeyedReversePriorityQueue::new(),
         }
     }
 
     pub fn peek(&self) -> Option<(&SequenceNumber, &Duration)> {
-        self.items.peek().map(|(k, p)| (k, &p.inner))
+        self.items.peek()
     }
 
     pub fn pop(&mut self) -> Option<(SequenceNumber, Duration)> {
-        self.items.pop().map(|(k, p)| (k, p.inner))
+        self.items.pop()
     }
 
     pub fn push(&mut self, key: SequenceNumber, priority: Duration) -> Option<Duration> {
-        self.items
-            .push(key, ReverseOrdered::from(priority))
-            .map(|rd| rd.inner)
+        self.items.push(key, priority)
     }
 
     pub fn update(
@@ -85,11 +38,8 @@ impl PollQueue {
         key: SequenceNumber,
         priority: Duration,
     ) -> Result<Duration, PollQueueUpdateFailure> {
-        match self
-            .items
-            .set_priority(&key, ReverseOrdered::from(priority))
-        {
-            Ok(priority) => Ok(priority.inner),
+        match self.items.set_priority(&key, priority) {
+            Ok(priority) => Ok(priority),
             Err(_) => Err(PollQueueUpdateFailure::UnknownSequence(key)),
         }
     }


### PR DESCRIPTION
The motivation for this is that we might use this to schedule
callbacks in the `cli` crate.

## Pull Request template

Please, fill in the following checklist when you submit a PR.  The
items you have done should be updated with a check mark (that is,
`[x]` instead of `[ ]`).

* [x] Review the [CONTRIBUTING.md](../CONTRIBUTING.md) file for
      detailed contributing guidelines before sending a PR.
* [x] Your contribution is made under the project's [copyright
      license](../LICENSE-MIT).
* [x] Make sure that your PR is not a duplicate.
* [x] You have done your changes in a separate branch.
* [x] You have a descriptive commit message with a short title (first line).
* [x] You have only one commit.  If not, either squash them into one
      commit or contribute your change as a sequence of smaller Pull
      Requests.
* [x] Your changes include unit tests (if they are code changes).
* [x] `cargo test` passes.
* [x] `cargo clippy` does not generate any warnings.
* [x] Your code is formatted with `cargo fmt`.
* If your change is a bugfix and it fully fixes an issue:
   * [ ] Put `closes #XXXX` in your commit message to auto-close the
         issue that your PR fixes.
* [ ] If your change relates to the behaviour of the simulator, please
      include comments explaining which part of the [reference
      documentation](https://tx-2.github.io/documentation.html)
      describes the thing you're changing.

If any of the checklist items don't apply, please leave them
un-checked.

**PLEASE KEEP THE ABOVE IN YOUR PULL REQUEST.**
