### PR TITLE
Provide Context object to avoid RTC calling SystemTime::now().

### DIFF
--- a/cpu/src/context.rs
+++ b/cpu/src/context.rs
@@ -1,0 +1,15 @@
+use core::time::Duration;
+
+pub struct Context {
+    pub simulated_time: Duration,
+    pub real_elapsed_time: Duration,
+}
+
+impl Context {
+    pub fn new(simulated_time: Duration, real_elapsed_time: Duration) -> Context {
+        Context {
+            simulated_time,
+            real_elapsed_time,
+        }
+    }
+}

--- a/cpu/src/control/trap.rs
+++ b/cpu/src/control/trap.rs
@@ -4,6 +4,7 @@ use base::prelude::*;
 use std::time::Duration;
 
 use super::super::*;
+use crate::context::Context;
 use crate::event::InputEvent;
 use crate::io::{Unit, UnitStatus};
 
@@ -110,7 +111,7 @@ impl TrapCircuit {
 }
 
 impl Unit for TrapCircuit {
-    fn poll(&mut self, _system_time: &Duration) -> UnitStatus {
+    fn poll(&mut self, ctx: &Context) -> UnitStatus {
         UnitStatus {
             special: Unsigned12Bit::ZERO,
             change_flag: None,
@@ -119,12 +120,12 @@ impl Unit for TrapCircuit {
             missed_data: false,
             mode: self.mode,
             // The trap circuit does not need to be polled.
-            poll_after: Duration::from_secs(60),
+            poll_after: ctx.simulated_time + Duration::from_secs(60),
             is_input_unit: true,
         }
     }
 
-    fn connect(&mut self, _system_time: &Duration, mode: Unsigned12Bit) {
+    fn connect(&mut self, _ctx: &Context, mode: Unsigned12Bit) {
         self.mode = mode;
     }
 
@@ -136,7 +137,7 @@ impl Unit for TrapCircuit {
     /// cycle-left and dismiss features (See Users Handbook, section
     /// 4-15 ("TRAP").  Because it cycles left, it must be an "input"
     /// unit.
-    fn read(&mut self, _system_time: &Duration) -> Result<MaskedWord, TransferFailed> {
+    fn read(&mut self, _ctx: &Context) -> Result<MaskedWord, TransferFailed> {
         // TODO: add unit tests for the cycle-left and dismiss
         // behaviours.
         Ok(MaskedWord {
@@ -149,7 +150,7 @@ impl Unit for TrapCircuit {
     /// unit or an output unit.
     fn write(
         &mut self,
-        _system_time: &Duration,
+        _ctx: &Context,
         _source: Unsigned36Bit,
     ) -> Result<Option<OutputEvent>, TransferFailed> {
         unreachable!()
@@ -159,11 +160,11 @@ impl Unit for TrapCircuit {
         "trap circuit".to_string()
     }
 
-    fn disconnect(&mut self, _system_time: &Duration) {
+    fn disconnect(&mut self, _ctx: &Context) {
         // Does nothing.
     }
 
-    fn on_input_event(&mut self, _event: InputEvent) {
+    fn on_input_event(&mut self, _ctx: &Context, _event: InputEvent) {
         // Does nothing.
     }
 }

--- a/cpu/src/io/dev_petr.rs
+++ b/cpu/src/io/dev_petr.rs
@@ -277,7 +277,8 @@ impl Petr {
 }
 
 impl Unit for Petr {
-    fn poll(&mut self, system_time: &Duration) -> UnitStatus {
+    fn poll(&mut self, ctx: &Context) -> UnitStatus {
+        let system_time = &ctx.simulated_time;
         self.maybe_simulate_event(system_time);
         let data_ready: bool = self.data.is_some();
         let poll_after = self.next_poll_time(system_time);
@@ -298,7 +299,8 @@ impl Unit for Petr {
         }
     }
 
-    fn connect(&mut self, system_time: &Duration, mode: Unsigned12Bit) {
+    fn connect(&mut self, ctx: &Context, mode: Unsigned12Bit) {
+        let system_time = &ctx.simulated_time;
         self.direction = if mode & 0o04 != 0 {
             Direction::Bin
         } else {
@@ -333,7 +335,8 @@ impl Unit for Petr {
         self.transfer_mode()
     }
 
-    fn read(&mut self, system_time: &Duration) -> Result<MaskedWord, TransferFailed> {
+    fn read(&mut self, ctx: &Context) -> Result<MaskedWord, TransferFailed> {
+        let system_time = &ctx.simulated_time;
         match self.data.take() {
             None => {
                 event!(Level::DEBUG, "no data is ready yet");
@@ -355,7 +358,7 @@ impl Unit for Petr {
 
     fn write(
         &mut self,
-        _system_time: &Duration,
+        _ctx: &Context,
         _source: Unsigned36Bit,
     ) -> Result<Option<OutputEvent>, TransferFailed> {
         unreachable!()
@@ -365,11 +368,11 @@ impl Unit for Petr {
         "PETR photoelectric paper tape reader".to_string()
     }
 
-    fn disconnect(&mut self, _system_time: &Duration) {
+    fn disconnect(&mut self, _ctx: &Context) {
         self.activity = Activity::Stopped;
     }
 
-    fn on_input_event(&mut self, event: InputEvent) {
+    fn on_input_event(&mut self, _ctx: &Context, event: InputEvent) {
         match event {
             InputEvent::PetrMountPaperTape { data } => {
                 event!(Level::DEBUG, "Mounting a tape ({} bytes)", data.len());

--- a/cpu/src/lib.rs
+++ b/cpu/src/lib.rs
@@ -3,6 +3,7 @@
 #![crate_name = "cpu"]
 
 mod alarm;
+mod context;
 mod control;
 mod event;
 mod exchanger;
@@ -12,6 +13,7 @@ mod tx2;
 mod types;
 
 pub use alarm::{Alarm, UnmaskedAlarm};
+pub use context::Context;
 pub use control::{ControlUnit, PanicOnUnmaskedAlarm, ResetMode, RunMode};
 pub use event::*;
 pub use io::{set_up_peripherals, DeviceManager};


### PR DESCRIPTION
The RTC should not call SystemTime::now() because the RTC is part of
the V memory implementation, and that needs to be able to run in
environments (e.g. WASM) that lack support for SystemTime::now().

(In a WASM environment, SystemTime::now() will panic)

## Pull Request template

Please, fill in the following checklist when you submit a PR.  The
items you have done should be updated with a check mark (that is,
`[x]` instead of `[ ]`).

* [x] Review the [CONTRIBUTING.md](../CONTRIBUTING.md) file for
      detailed contributing guidelines before sending a PR.
* [x] Your contribution is made under the project's [copyright
      license](../LICENSE-MIT).
* [x] Make sure that your PR is not a duplicate.
* [x] You have done your changes in a separate branch.
* [x] You have a descriptive commit message with a short title (first line).
* [x] You have only one commit.  If not, either squash them into one
      commit or contribute your change as a sequence of smaller Pull
      Requests.
* [x] Your changes include unit tests (if they are code changes).
* [x] `cargo test` passes.
* [x] `cargo clippy` does not generate any warnings.
* [x] Your code is formatted with `cargo fmt`.
* If your change is a bugfix and it fully fixes an issue:
   * [ ] Put `closes #XXXX` in your commit message to auto-close the
         issue that your PR fixes.
* [ ] If your change relates to the behaviour of the simulator, please
      include comments explaining which part of the [reference
      documentation](https://tx-2.github.io/documentation.html)
      describes the thing you're changing.

If any of the checklist items don't apply, please leave them
un-checked.

**PLEASE KEEP THE ABOVE IN YOUR PULL REQUEST.**

Tested manually by running hello.tape.
