### PR TITLE
Resolve clippy warnings

### DIFF
--- a/assembler/src/asmlib/ast.rs
+++ b/assembler/src/asmlib/ast.rs
@@ -1828,7 +1828,7 @@ impl InstructionSequence {
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub(crate) fn build_binary_block<'s, R: RcUpdater>(
+    pub(crate) fn build_binary_block<R: RcUpdater>(
         &self,
         location: Address,
         start_offset: Unsigned18Bit,
@@ -1838,7 +1838,7 @@ impl InstructionSequence {
         index_register_assigner: &mut IndexRegisterAssigner,
         rc_allocator: &mut R,
         final_symbols: &mut FinalSymbolTable,
-        body: &Source<'s>,
+        body: &Source<'_>,
         listing: &mut Listing,
         bad_symbol_definitions: &mut BTreeMap<SymbolName, ProgramError>,
     ) -> Result<Vec<Unsigned36Bit>, AssemblerFailure> {

--- a/assembler/src/asmlib/symtab.rs
+++ b/assembler/src/asmlib/symtab.rs
@@ -440,8 +440,8 @@ pub(super) fn assign_default_rc_word_tags<R: RcAllocator>(
     Ok(())
 }
 
-pub(super) fn record_undefined_symbol_or_return_failure<'s>(
-    source_file_body: &Source<'s>,
+pub(super) fn record_undefined_symbol_or_return_failure(
+    source_file_body: &Source<'_>,
     e: SymbolLookupFailure,
     undefined_symbols: &mut BTreeMap<SymbolName, ProgramError>,
 ) -> Result<(), AssemblerFailure> {


### PR DESCRIPTION
* General
   * [x] Review the [CONTRIBUTING.md](../CONTRIBUTING.md) file for
         detailed contributing guidelines before sending a PR.
   * [x] Your contribution is made under the project's [copyright
         license](../LICENSE-MIT).
   * [x] Make sure that your PR is not a duplicate.
   * [x] You have done your changes in a separate branch.
   * [x] You have a descriptive commit message with a short title (first line).
   * [x] You have only one commit.  If not, either squash them into one
         commit or contribute your change as a sequence of smaller Pull
         Requests.
* Basic sanity checks
   * [x] You have run `runchecks.sh` and it said "Everything is OK".
* Testing and Documentation
   * [x] Your changes include unit tests (if they are code changes).
   * [x] If your change relates to the behaviour of the simulator, please
         include comments explaining which part of the [reference
         documentation](https://tx-2.github.io/documentation.html)
         describes the thing you're changing.
* If your change is a bugfix and it fully fixes an issue:
   * [x] Put `closes #XXXX` in your pull request description to
         auto-close the issue that your PR fixes.

If any of the checklist items don't apply, please leave them
un-checked.

---

Resolves the following:

```
[nix-shell:~/Development/TX-2-simulator]$ cargo clippy --workspace
   Compiling psm v0.1.26
    Checking stacker v0.1.21
    Checking chumsky v1.0.0-alpha.8
    Checking assembler v0.1.0 (/home/aryehh/Development/TX-2-simulator/assembler)
warning: the following explicit lifetimes could be elided: 's
    --> assembler/src/asmlib/ast.rs:1831:38
     |
1831 |     pub(crate) fn build_binary_block<'s, R: RcUpdater>(
     |                                      ^^
...
1841 |         body: &Source<'s>,
     |                       ^^
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
     = note: `#[warn(clippy::needless_lifetimes)]` on by default
help: elide the lifetimes
     |
1831 ~     pub(crate) fn build_binary_block<R: RcUpdater>(
1832 |         &self,
...
1840 |         final_symbols: &mut FinalSymbolTable,
1841 ~         body: &Source<'_>,
     |

warning: the following explicit lifetimes could be elided: 's
   --> assembler/src/asmlib/symtab.rs:443:57
    |
443 | pub(super) fn record_undefined_symbol_or_return_failure<'s>(
    |                                                         ^^
444 |     source_file_body: &Source<'s>,
    |                               ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
443 ~ pub(super) fn record_undefined_symbol_or_return_failure(
444 ~     source_file_body: &Source<'_>,
    |

warning: `assembler` (lib) generated 2 warnings (run `cargo clippy --fix --lib -p assembler` to apply 2 suggestions)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.82s
```